### PR TITLE
fix(ops): sizes == -1 was interpreted incorrectly

### DIFF
--- a/tf2jax/_src/ops.py
+++ b/tf2jax/_src/ops.py
@@ -1807,7 +1807,7 @@ def _slice(proto):
       sizes: jnp.ndarray,
   ) -> jnp.ndarray:
     """`begins` and `sizes` must be concrete arrays."""
-    slices = [slice(b, b + s) for b, s in safe_zip(begins, sizes)]
+    slices = [slice(b, b + s if slice != -1 else None) for b, s in safe_zip(begins, sizes)]
     return x[tuple(slices)]
 
   return _func

--- a/tf2jax/_src/ops_test.py
+++ b/tf2jax/_src/ops_test.py
@@ -1721,7 +1721,7 @@ class OpsTest(test_util.TestCase):
 
   @chex.variants(with_jit=True, without_jit=True)
   def test_slice(self):
-    inputs, begins, sizes = [np.array([[1, 2], [3, 4], [5, 6]]), [1, 1], [2, 1]]
+    inputs, begins, sizes = [np.array([[1, 2], [3, 4], [5, 6]]), [1, 1], [2, -1]]
 
     def slice_fn(xs):
       return tf.raw_ops.Slice(input=xs, begin=begins, size=sizes)


### PR DESCRIPTION
tf.slice does not act like tf.get_item (eg, python)

from 
https://www.tensorflow.org/api_docs/python/tf/slice

> If size[i] is -1, all remaining elements in dimension i are included in the slice. In other words, this is equivalent to setting:

`size[i] = input_.dim_size(i) - begin[i]`

this likely fixes the bfloat optimizations size issues in the TPU Inference Converter as well.